### PR TITLE
Adding the folder name in the tooltip of the visualisation

### DIFF
--- a/src/chrome/content/ContainerVisualisation.js
+++ b/src/chrome/content/ContainerVisualisation.js
@@ -295,6 +295,20 @@ var ThreadVis = (function(ThreadVis) {
                 subjectLabel.style.fontWeight = "bold";
                 subjectText.setAttribute("value", this._container.getMessage()
                         .getSubject());
+                
+                var folderLabel = document.createElementNS(
+                        ThreadVis.XUL_NAMESPACE, "label");
+                var folderText = document.createElementNS(
+                        ThreadVis.XUL_NAMESPACE, "label");
+                var folder = document.createElementNS(ThreadVis.XUL_NAMESPACE,
+                        "hbox");
+                folder.appendChild(folderLabel);
+                folder.appendChild(folderText);
+                folderLabel.setAttribute("value", ThreadVis.strings
+                        .getString("tooltip.folder"));
+                folderLabel.style.fontWeight = "bold";
+                folderText.setAttribute("value", this._container.getMessage()
+                        .getFolderName());
 
                 var body = document.createElementNS(ThreadVis.XUL_NAMESPACE,
                         "description");
@@ -305,6 +319,7 @@ var ThreadVis = (function(ThreadVis) {
                 this._tooltip.appendChild(author);
                 this._tooltip.appendChild(date);
                 this._tooltip.appendChild(subject);
+                this._tooltip.appendChild(folder);
                 this._tooltip.appendChild(document.createElementNS(
                         ThreadVis.XUL_NAMESPACE, "separator"));
                 this._tooltip.appendChild(body);

--- a/src/chrome/content/Message.js
+++ b/src/chrome/content/Message.js
@@ -1,1 +1,231 @@
-/* ***************************************************************************** * This file is part of ThreadVis. * http://threadvis.github.io * * ThreadVis started as part of Alexander C. Hubmann-Haidvogel's Master's Thesis * titled "ThreadVis for Thunderbird: A Thread Visualisation Extension for the * Mozilla Thunderbird Email Client" at Graz University of Technology, Austria. * An electronic version of the thesis is available online at * http://www.iicm.tugraz.at/ahubmann.pdf * * Copyright (C) 2005, 2006, 2007 Alexander C. Hubmann * Copyright (C) 2007, 2008, 2009, 2010, 2011, *               2013 Alexander C. Hubmann-Haidvogel * * ThreadVis is free software: you can redistribute it and/or modify it under * the terms of the GNU Affero General Public License as published by the Free * Software Foundation, either version 3 of the License, or (at your option) any * later version. * * ThreadVis is distributed in the hope that it will be useful, but WITHOUT ANY * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more * details. * * You should have received a copy of the GNU Affero General Public License * along with ThreadVis. If not, see <http://www.gnu.org/licenses/>. * * Version: $Id$ * ***************************************************************************** * Wrap email message ******************************************************************************/var ThreadVis = (function(ThreadVis) {    /**     * Constructor     *      * @constructor     * @param {glodaMessage} glodaMessage     *              The gloda message object     * @return {ThreadVis.Message} A new message     * @type ThreadVis.Message     */    ThreadVis.Message = function(glodaMessage) {        /**         * Gloda message         */        this._glodaMessage = glodaMessage;        /**         * References of this message         */        if (glodaMessage.folderMessage != null) {            this._references = new ThreadVis.References(                    glodaMessage.folderMessage.getStringProperty("references"));        } else {            this._references = new ThreadVis.References("");        }    };    /**     * Prototype / instance methods     */    ThreadVis.Message.prototype = {        /**         * Gloda message         */        _glodaMessage : null,        /**         * References of this message         */        _references : null,        /**         * Get date of message         *          * @return {Date} The date of the message         * @type Date         */        getDate : function() {            return this._glodaMessage.date;        },        /**         * Get folder message is in         *          * @return {String} The folder of the message         * @type String         */        getFolder : function() {            return this._glodaMessage.folderURI;        },        /**         * Get sender of message         *          * @return {String} The sender of the message         * @type String         */        getFrom : function() {            if (this._glodaMessage.folderMessage != null) {                return this._glodaMessage.folderMessage.mime2DecodedAuthor;            }            return this._glodaMessage.from;        },        /**         * Parse email address from "From" header         *          * @return {String} The parsed email address         * @type String         */        getFromEmail : function() {            return this._glodaMessage.from.value;        },        /**         * Get message id         *          * @return {String} The message id         * @type String         */        getId : function() {            return this._glodaMessage.headerMessageID;        },        /**         * Get references         *          * @return {String} The referenced header         * @type String         */        getReferences : function() {            return this._references;        },        /**         * Get original subject         *          * @return {String} The subject         * @type String         */        getSubject : function() {            return this._glodaMessage.subject;        },        /**         * See if message is sent (i.e. in sent-mail folder)         *          * @return {Boolean} True if the message was sent by the user, false if         *         not         * @type Boolean         */        isSent : function() {            var issent = false;            // it is sent if it is stored in a folder that is marked as sent            // (if enabled)            if (this._glodaMessage.folderMessage != null) {                issent |= this._glodaMessage.folderMessage.folder.isSpecialFolder(                                Components.interfaces.nsMsgFolderFlags.SentMail,                                true)                        && ThreadVis.Preferences.getPreference(                                ThreadVis.Preferences.PREF_SENTMAIL_FOLDERFLAG);            }            // or it is sent if the sender address is a local identity            // (if enabled)            issent |= ThreadVis.sentMailIdentities[this._glodaMessage.from.value] == true                    && ThreadVis.Preferences.getPreference(                            ThreadVis.Preferences.PREF_SENTMAIL_IDENTITY);            return issent;        },        /**         * Get body of message         *          * @return {String} The body of the message         * @type String         */        getBody : function() {            return this._glodaMessage.indexedBodyText;        },        /**         * Return message as string         *          * @return {String} The string representation of the message         * @type String         */        toString : function() {            return "Message: Subject: '" + this.getSubject() + "'. From: '"                    + this.getFrom() + "'. MsgId: '" + this.getId()                    + "'. Date: '" + this.getDate() + "'. Folder: '"                    + this.getFolder() + "'. Refs: '" + this.getReferences()                    + "'. Sent: '" + this.isSent() + "'";        },        /**         * Get the underlying nsIMsgDBHdr         *          * @return {nsIMsgDBHdr} The original nsIMsgDBHdr or null if not found         * @type nsIMsgDBHdr         */        getMsgDbHdr : function() {            if (this._glodaMessage.folderMessage == null) {                ThreadVis.log(                        "Cache",                        "Unable to find nsIMsgDBHdr for message "                         + this.getId() + ", probably in folder "                        + this.getFolder()                        + ". Either the message database (msf) for this folder is corrupt, or the global index is out-of-date.");            }            return this._glodaMessage.folderMessage;        }    };    return ThreadVis;}(ThreadVis || {}));
+/* *****************************************************************************
+ * This file is part of ThreadVis.
+ * http://threadvis.github.io
+ *
+ * ThreadVis started as part of Alexander C. Hubmann-Haidvogel's Master's Thesis
+ * titled "ThreadVis for Thunderbird: A Thread Visualisation Extension for the
+ * Mozilla Thunderbird Email Client" at Graz University of Technology, Austria.
+ * An electronic version of the thesis is available online at
+ * http://www.iicm.tugraz.at/ahubmann.pdf
+ *
+ * Copyright (C) 2005, 2006, 2007 Alexander C. Hubmann
+ * Copyright (C) 2007, 2008, 2009, 2010, 2011,
+ *               2013 Alexander C. Hubmann-Haidvogel
+ *
+ * ThreadVis is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * ThreadVis is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with ThreadVis. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Version: $Id$
+ * *****************************************************************************
+ * Wrap email message
+ ******************************************************************************/
+
+var ThreadVis = (function(ThreadVis) {
+
+    /**
+     * Constructor
+     * 
+     * @constructor
+     * @param {glodaMessage} glodaMessage
+     *              The gloda message object
+     * @return {ThreadVis.Message} A new message
+     * @type ThreadVis.Message
+     */
+    ThreadVis.Message = function(glodaMessage) {
+        /**
+         * Gloda message
+         */
+        this._glodaMessage = glodaMessage;
+
+        /**
+         * References of this message
+         */
+        if (glodaMessage.folderMessage != null) {
+            this._references = new ThreadVis.References(
+                    glodaMessage.folderMessage.getStringProperty("references"));
+        } else {
+            this._references = new ThreadVis.References("");
+        }
+    };
+
+    /**
+     * Prototype / instance methods
+     */
+    ThreadVis.Message.prototype = {
+        /**
+         * Gloda message
+         */
+        _glodaMessage : null,
+
+        /**
+         * References of this message
+         */
+        _references : null,
+
+        /**
+         * Get date of message
+         * 
+         * @return {Date} The date of the message
+         * @type Date
+         */
+        getDate : function() {
+            return this._glodaMessage.date;
+        },
+
+        /**
+         * Get folder message is in
+         * 
+         * @return {String} The folder of the message
+         * @type String
+         */
+        getFolder : function() {
+            return this._glodaMessage.folderURI;
+        },
+      
+      /**
+         * Get folder name message is in
+         * 
+         * @return {String} The sender of the message
+         * @type String
+         */
+        getFolderName : function() {
+            if (this._glodaMessage.folderMessage != null) {
+                return this._glodaMessage.folderMessage.folder.prettiestName;
+            }
+            return "";
+        },
+
+        /**
+         * Get sender of message
+         * 
+         * @return {String} The sender of the message
+         * @type String
+         */
+        getFrom : function() {
+            if (this._glodaMessage.folderMessage != null) {
+                return this._glodaMessage.folderMessage.mime2DecodedAuthor;
+            }
+            return this._glodaMessage.from;
+        },
+
+        /**
+         * Parse email address from "From" header
+         * 
+         * @return {String} The parsed email address
+         * @type String
+         */
+        getFromEmail : function() {
+            return this._glodaMessage.from.value;
+        },
+
+        /**
+         * Get message id
+         * 
+         * @return {String} The message id
+         * @type String
+         */
+        getId : function() {
+            return this._glodaMessage.headerMessageID;
+        },
+
+        /**
+         * Get references
+         * 
+         * @return {String} The referenced header
+         * @type String
+         */
+        getReferences : function() {
+            return this._references;
+        },
+
+        /**
+         * Get original subject
+         * 
+         * @return {String} The subject
+         * @type String
+         */
+        getSubject : function() {
+            return this._glodaMessage.subject;
+        },
+
+        /**
+         * See if message is sent (i.e. in sent-mail folder)
+         * 
+         * @return {Boolean} True if the message was sent by the user, false if
+         *         not
+         * @type Boolean
+         */
+        isSent : function() {
+            var issent = false;
+            // it is sent if it is stored in a folder that is marked as sent
+            // (if enabled)
+            if (this._glodaMessage.folderMessage != null) {
+                issent |= this._glodaMessage.folderMessage.folder.isSpecialFolder(
+                                Components.interfaces.nsMsgFolderFlags.SentMail,
+                                true)
+                        && ThreadVis.Preferences.getPreference(
+                                ThreadVis.Preferences.PREF_SENTMAIL_FOLDERFLAG);
+            }
+            // or it is sent if the sender address is a local identity
+            // (if enabled)
+            issent |= ThreadVis.sentMailIdentities[this._glodaMessage.from.value] == true
+                    && ThreadVis.Preferences.getPreference(
+                            ThreadVis.Preferences.PREF_SENTMAIL_IDENTITY);
+            return issent;
+        },
+
+        /**
+         * Get body of message
+         * 
+         * @return {String} The body of the message
+         * @type String
+         */
+        getBody : function() {
+            return this._glodaMessage.indexedBodyText;
+        },
+
+        /**
+         * Return message as string
+         * 
+         * @return {String} The string representation of the message
+         * @type String
+         */
+        toString : function() {
+            return "Message: Subject: '" + this.getSubject() + "'. From: '"
+                    + this.getFrom() + "'. MsgId: '" + this.getId()
+                    + "'. Date: '" + this.getDate() + "'. Folder: '"
+                    + this.getFolder() + "'. Refs: '" + this.getReferences()
+                    + "'. Sent: '" + this.isSent() + "'";
+        },
+
+        /**
+         * Get the underlying nsIMsgDBHdr
+         * 
+         * @return {nsIMsgDBHdr} The original nsIMsgDBHdr or null if not found
+         * @type nsIMsgDBHdr
+         */
+        getMsgDbHdr : function() {
+            if (this._glodaMessage.folderMessage == null) {
+                ThreadVis.log(
+                        "Cache",
+                        "Unable to find nsIMsgDBHdr for message " 
+                        + this.getId() + ", probably in folder "
+                        + this.getFolder()
+                        + ". Either the message database (msf) for this folder is corrupt, or the global index is out-of-date.");
+            }
+            return this._glodaMessage.folderMessage;
+        }
+    };
+
+    return ThreadVis;
+}(ThreadVis || {}));

--- a/src/chrome/locale/de-DE/ThreadVis.properties
+++ b/src/chrome/locale/de-DE/ThreadVis.properties
@@ -38,6 +38,7 @@ extensions.{A23E4120-431F-4753-AE53-5D028C42CFDC}.description=Zeigt eine kleine 
 tooltip.from=Von:
 tooltip.date=Datum:
 tooltip.subject=Betreff:
+tooltip.folder=Folder:
 tooltip.missingmessage=Das ist eine fehlende Nachricht.
 tooltip.missingmessagedetail=Entweder haben Sie sie nie erhalten oder sie wurde gel\u00F6scht.
 visualisation.loading=ThreadVis wird geladen ...

--- a/src/chrome/locale/en-US/ThreadVis.properties
+++ b/src/chrome/locale/en-US/ThreadVis.properties
@@ -33,6 +33,7 @@ extensions.{A23E4120-431F-4753-AE53-5D028C42CFDC}.description=Displays a small g
 tooltip.from=From:
 tooltip.date=Date:
 tooltip.subject=Subject:
+tooltip.folder=Folder:
 tooltip.missingmessage=This is a missing message.
 tooltip.missingmessagedetail=Either you never received it or it was deleted.
 visualisation.loading=Loading ThreadVis ...


### PR DESCRIPTION
I wanted to be able to view for a message in a thread in which folder it is.
So I added it to the tooltip.
I'm pretty new to both Thunderbird plugins and github, so excuse me if I did things wrong.

A few comments about it:
- I wanted to see the whole path. And the function getFolder already provides that, but it also includes the account in the string, and makes it very long. So I created a dedicated function called getFolderName which returns only the current folder name.
- in the getFolderName function, I'm not sure when it can happen that the message is null. So in such cases, I don't know what it should return.
- I don't speak German, so I put the same string in German