### PR TITLE
Update manifest strict_max_version 144.*

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,7 +34,7 @@
         "gecko": {
             "id": "{A23E4120-431F-4753-AE53-5D028C42CFDC}",
             "strict_min_version": "128.0",
-            "strict_max_version": "143.*"
+            "strict_max_version": "144.*"
         }
     },
     "name": "__MSG_extensionName__",


### PR DESCRIPTION
add-on is working unchanged in Thunderbird 144.*, just update manifest strict_max_version